### PR TITLE
Resolve #1 by recommendation from apt-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A PPA repository for my packages:
 # Usage
 
 ```bash
-curl -SsL https://assafmo.github.io/ppa/ubuntu/KEY.gpg | sudo apt-key add -
+sudo curl -SsL -o /etc/apt/trusted.gpg.d/assafmo.gpg https://assafmo.github.io/ppa/ubuntu/KEY.gpg
 sudo curl -SsL -o /etc/apt/sources.list.d/assafmo.list https://assafmo.github.io/ppa/ubuntu/assafmo.list
 sudo apt update
 sudo apt install joincap xioc sqlitequeryserver


### PR DESCRIPTION
Resolve #1 by removing dependence on `apt-key add`

For posterity: 
```
add filename (deprecated)
   Add a new key to the list of trusted keys. The key is read from the filename given with the parameter filename or if the filename is - from standard input.

   It is critical that keys added manually via apt-key are verified to belong to the owner of the repositories they claim to be for otherwise the apt-secure(8) infrastructure is completely undermined.

   Note: Instead of using this command a keyring should be placed directly in the /etc/apt/trusted.gpg.d/ directory with a descriptive name andeither "gpg" or "asc" as file extension.
   ```